### PR TITLE
sharp peer dependency could be any in range 0 =< 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ts-node": "^10.8.1"
       },
       "peerDependencies": {
-        "sharp": "^0.32.5"
+        "sharp": "> 0.0.1 < 1.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "smartcrop": "^2.0.5"
   },
   "peerDependencies": {
-    "sharp": "^0.32.5"
+    "sharp": "> 0.0.1 < 1.0.0"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
Sounds like sharp peer dependency needs manual resolve every time it's updated...

[I googled around and found that using asterics is a bad practice](https://stackoverflow.com/questions/47309598/make-your-npm-package-support-multiple-versions-of-peer-dependency)

So, I think we are relatively safe with any version < 1, as 1 will be breaking change (fair to guess).

Also, this update does not enforce users who already work with old sharp version to update it, they are safe to keep using the old version.

Here is a [nice version calculator to check if anything needed](https://semver.npmjs.com/)  